### PR TITLE
Add server-side search to legislation table

### DIFF
--- a/legislation
+++ b/legislation
@@ -183,6 +183,7 @@ let loading = false;
 let endReached = false;
 let currentSearchTerm = '';
 let searchDebounceTimer = null;
+let fetchedCount = 0;
 
 function showLoading(message = 'Loading...') {
   document.getElementById('table-content').innerHTML = `<tr><td colspan="6">${message}</td></tr>`;
@@ -214,7 +215,7 @@ async function loadMore(searchTerm = '') {
   if (loading || endReached) return;
   loading = true;
   try {
-    const skip = allMatters.length;
+    const skip = fetchedCount;
     let filterQuery = '';
     if (searchTerm) {
       const escaped = escapeODataString(searchTerm.toLowerCase());
@@ -230,6 +231,7 @@ async function loadMore(searchTerm = '') {
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
     allMatters = allMatters.concat(data);
+    fetchedCount += data.length;
     if (data.length < BATCH_SIZE) endReached = true;
     populateTypeFilter();
   } catch (err) {
@@ -255,6 +257,7 @@ async function performServerSearch() {
     allMatters = [];
     filteredMatters = [];
     currentPage = 1;
+    fetchedCount = 0;
     endReached = false;
     showLoading('Searching...');
     await loadMore(searchTerm);

--- a/legislation
+++ b/legislation
@@ -1,0 +1,340 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Latest Legislation</title>
+<style>
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  background: #f7f8f9;
+  color: #2d3748;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.header {
+  background: white;
+  border-radius: 12px;
+  padding: 1.5rem 2rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #1a202c;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.controls input,
+.controls select,
+.controls button {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #cbd5e0;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  background: white;
+}
+
+.controls button {
+  cursor: pointer;
+}
+
+.table-container {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+}
+
+.legislation-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.legislation-table thead {
+  background: #f7fafc;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.legislation-table th {
+  text-align: left;
+  padding: 1rem 1.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #4a5568;
+}
+
+.legislation-table td {
+  padding: 1rem 1.5rem;
+  font-size: 0.875rem;
+  border-bottom: 1px solid #edf2f7;
+}
+
+.legislation-table tbody tr {
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.legislation-table tbody tr:hover {
+  background: #f7fafc;
+}
+
+.pagination {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  font-size: 0.875rem;
+}
+
+.pagination button {
+  padding: 0.5rem 0.75rem;
+  background: #3182ce;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.pagination button:disabled {
+  background: #cbd5e0;
+  cursor: not-allowed;
+}
+
+</style>
+</head>
+<body>
+<div class="container">
+  <div class="header">
+    <h1 class="title">Latest Legislation</h1>
+    <div class="controls">
+      <input type="text" id="search-input" placeholder="Search..." />
+      <button id="clear-search">Clear</button>
+      <select id="type-filter">
+        <option value="all">All Types</option>
+      </select>
+      <select id="page-size">
+        <option value="6" selected>6 per page</option>
+        <option value="10">10 per page</option>
+        <option value="20">20 per page</option>
+      </select>
+    </div>
+  </div>
+  <div class="table-container">
+    <table class="legislation-table">
+      <thead>
+        <tr>
+          <th>File #</th>
+          <th>Title</th>
+          <th>Type</th>
+          <th>Body</th>
+          <th>Status</th>
+          <th>Introduced</th>
+        </tr>
+      </thead>
+      <tbody id="table-content">
+        <tr><td colspan="6">Loading...</td></tr>
+      </tbody>
+    </table>
+    <div class="pagination">
+      <button id="prev-btn">Prev</button>
+      <span id="page-info">Page 1</span>
+      <button id="next-btn">Next</button>
+    </div>
+  </div>
+</div>
+<script>
+const CONFIG = {
+  baseUrl: 'https://webapi.legistar.com/v1/nashville',
+  corsProxy: 'https://corsproxy.io/?',
+  softrDomain: 'https://eonashville.preview.softr.app'
+};
+
+const BATCH_SIZE = 100;
+let allMatters = [];
+let filteredMatters = [];
+let currentPage = 1;
+let pageSize = 6;
+let loading = false;
+let endReached = false;
+let currentSearchTerm = '';
+let searchDebounceTimer = null;
+
+function showLoading(message = 'Loading...') {
+  document.getElementById('table-content').innerHTML = `<tr><td colspan="6">${message}</td></tr>`;
+}
+
+function escapeODataString(str) {
+  return str.replace(/'/g, "''");
+}
+
+function formatDate(dateStr) {
+  return dateStr ? new Date(dateStr).toLocaleDateString() : '';
+}
+
+function populateTypeFilter() {
+  const select = document.getElementById('type-filter');
+  const current = select.value;
+  const types = Array.from(new Set(allMatters.map(m => m.MatterTypeName).filter(Boolean))).sort();
+  select.innerHTML = '<option value="all">All Types</option>';
+  types.forEach(t => {
+    const opt = document.createElement('option');
+    opt.value = t;
+    opt.textContent = t;
+    select.appendChild(opt);
+  });
+  if (types.includes(current)) select.value = current;
+}
+
+async function loadMore(searchTerm = '') {
+  if (loading || endReached) return;
+  loading = true;
+  try {
+    const skip = allMatters.length;
+    let filterQuery = '';
+    if (searchTerm) {
+      const escaped = escapeODataString(searchTerm.toLowerCase());
+      filterQuery = `&$filter=substringof('${escaped}',tolower(MatterTitle)) or ` +
+                   `substringof('${escaped}',tolower(MatterFile)) or ` +
+                   `substringof('${escaped}',tolower(MatterBodyName)) or ` +
+                   `substringof('${escaped}',tolower(MatterName))`;
+    }
+    const url = `${CONFIG.corsProxy}${encodeURIComponent(
+      `${CONFIG.baseUrl}/matters?$orderby=MatterIntroDate desc&$skip=${skip}&$top=${BATCH_SIZE}${filterQuery}`
+    )}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    allMatters = allMatters.concat(data);
+    if (data.length < BATCH_SIZE) endReached = true;
+    populateTypeFilter();
+  } catch (err) {
+    console.error('Failed to load legislation', err);
+    endReached = true;
+    showLoading('Search failed. Please try again.');
+  } finally {
+    loading = false;
+  }
+}
+
+async function ensureDataForPage(page) {
+  const needed = page * pageSize;
+  while (allMatters.length < needed && !endReached) {
+    await loadMore(currentSearchTerm);
+  }
+}
+
+async function performServerSearch() {
+  const searchTerm = document.getElementById('search-input').value.trim();
+  if (searchTerm !== currentSearchTerm) {
+    currentSearchTerm = searchTerm;
+    allMatters = [];
+    filteredMatters = [];
+    currentPage = 1;
+    endReached = false;
+    showLoading('Searching...');
+    await loadMore(searchTerm);
+    await renderTable();
+  }
+}
+
+async function renderTable() {
+  await ensureDataForPage(currentPage);
+  const typeFilter = document.getElementById('type-filter').value;
+  filteredMatters = allMatters.filter(m => {
+    const matchesType = typeFilter === 'all' || m.MatterTypeName === typeFilter;
+    return matchesType;
+  });
+  const totalPages = Math.ceil(filteredMatters.length / pageSize) || 1;
+  if (currentPage > totalPages) {
+    currentPage = totalPages;
+  }
+  const tbody = document.getElementById('table-content');
+  tbody.innerHTML = '';
+  const start = (currentPage - 1) * pageSize;
+  const pageItems = filteredMatters.slice(start, start + pageSize);
+  if (pageItems.length === 0) {
+    tbody.innerHTML = '<tr><td colspan="6">No results found.</td></tr>';
+  } else {
+    pageItems.forEach(matter => {
+      const link = `${CONFIG.softrDomain}/legislation-details?recordId=${matter.MatterId}`;
+      tbody.innerHTML += `
+        <tr onclick="window.location.href='${link}'">
+          <td>${matter.MatterFile}</td>
+          <td>${matter.MatterTitle || ''}</td>
+          <td>${matter.MatterTypeName || ''}</td>
+          <td>${matter.MatterBodyName || ''}</td>
+          <td>${matter.MatterStatusName || ''}</td>
+          <td>${formatDate(matter.MatterIntroDate)}</td>
+        </tr>`;
+    });
+  }
+  renderPagination(totalPages);
+}
+
+function renderPagination(totalPages) {
+  document.getElementById('page-info').textContent = `Page ${currentPage} of ${totalPages}`;
+  document.getElementById('prev-btn').disabled = currentPage === 1;
+  const atEnd = endReached && currentPage === totalPages;
+  document.getElementById('next-btn').disabled = atEnd;
+}
+
+document.getElementById('search-input').addEventListener('input', () => {
+  clearTimeout(searchDebounceTimer);
+  searchDebounceTimer = setTimeout(() => {
+    performServerSearch();
+  }, 500);
+});
+document.getElementById('clear-search').addEventListener('click', () => {
+  document.getElementById('search-input').value = '';
+  performServerSearch();
+});
+document.getElementById('type-filter').addEventListener('change', () => {
+  currentPage = 1;
+  renderTable();
+});
+document.getElementById('page-size').addEventListener('change', e => {
+  pageSize = parseInt(e.target.value, 10);
+  currentPage = 1;
+  renderTable();
+});
+document.getElementById('prev-btn').addEventListener('click', async () => {
+  if (currentPage > 1) {
+    currentPage--;
+    await renderTable();
+  }
+});
+document.getElementById('next-btn').addEventListener('click', async () => {
+  currentPage++;
+  await renderTable();
+});
+
+loadMore('').then(() => renderTable());
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- implement server-side search with OData filter to fetch filtered legislation results
- add debounced search input, clear button, and loading indicator
- maintain type filter and pagination with dynamic loading as users browse
- expand OData search to use substring matching across title, file, body, and name fields for broader results

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68957cfbd4e4833291239c7a04a10ab3