### PR TITLE
Redesign home page cards with overlay styling

### DIFF
--- a/home
+++ b/home
@@ -548,59 +548,52 @@
             display: grid;
             grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
             gap: 1.5rem;
+            grid-auto-flow: dense;
         }
 
         .card {
             background: var(--bg-secondary);
             border-radius: 12px;
-            border: 1px solid var(--border);
-            transition: all 0.2s;
-            cursor: pointer;
-            display: flex;
-            flex-direction: column;
             overflow: hidden;
-            position: relative;
+            cursor: pointer;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            transition: transform 0.2s, box-shadow 0.2s;
         }
 
         .card:hover {
             transform: translateY(-2px);
-            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
         }
 
-        .card-type-bar {
-            height: 4px;
-            background: var(--text-tertiary);
+        .card-image-container {
+            position: relative;
+            aspect-ratio: 4/3;
+            overflow: hidden;
+            background: var(--bg-card);
         }
 
-        .card[data-type="legislation"] .card-type-bar {
-            background: var(--type-legislation);
+        .card-featured {
+            grid-column: 1 / -1;
         }
 
-        .card[data-type="discussion"] .card-type-bar {
-            background: var(--type-discussion);
-        }
-
-        .card[data-type="news"] .card-type-bar {
-            background: var(--type-news);
+        .card-featured .card-image-container {
+            aspect-ratio: 16/9;
         }
 
         .card-image {
             width: 100%;
-            height: 200px;
+            height: 100%;
             object-fit: cover;
-            background: var(--bg-card);
         }
 
         .card-image-placeholder {
             width: 100%;
-            height: 200px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            height: 100%;
             display: flex;
             align-items: center;
             justify-content: center;
             color: white;
             font-size: 3rem;
-            opacity: 0.8;
         }
 
         .gradient-1 { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); }
@@ -611,115 +604,93 @@
         .gradient-6 { background: linear-gradient(135deg, #30cfd0 0%, #330867 100%); }
         .gradient-7 { background: linear-gradient(135deg, #fccb90 0%, #d57eeb 100%); }
 
-        .card-content {
-            padding: 1.5rem;
-            flex: 1;
-            display: flex;
-            flex-direction: column;
+        .text-overlay {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            padding: 30px 20px 20px;
+            background: linear-gradient(to bottom,
+                rgba(0,0,0,0) 0%,
+                rgba(0,0,0,0.4) 30%,
+                rgba(0,0,0,0.8) 100%);
+            color: white;
         }
 
-        .card-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: flex-start;
-            margin-bottom: 1rem;
-        }
-
-        .card-type-label {
-            font-size: 0.75rem;
+        .category-tag {
+            display: inline-block;
+            background: rgba(255,255,255,0.25);
+            backdrop-filter: blur(10px);
+            padding: 4px 12px;
+            border-radius: 20px;
+            font-size: 12px;
+            font-weight: 600;
             text-transform: uppercase;
-            letter-spacing: 0.05em;
-            color: var(--text-tertiary);
-            display: flex;
-            align-items: center;
-            gap: 0.375rem;
-        }
-
-        .card[data-type="legislation"] .card-type-label {
-            color: var(--type-legislation);
-        }
-
-        .card[data-type="discussion"] .card-type-label {
-            color: var(--type-discussion);
-        }
-
-        .card[data-type="news"] .card-type-label {
-            color: var(--type-news);
-        }
-
-        .card-source {
-            font-size: 0.75rem;
-            padding: 0.25rem 0.625rem;
-            border-radius: 12px;
-            background: var(--bg-card);
-            color: var(--text-secondary);
+            letter-spacing: 0.5px;
+            margin-bottom: 10px;
         }
 
         .card-title {
-            font-size: 1.125rem;
-            font-weight: 600;
-            line-height: 1.4;
-            margin-bottom: 0.75rem;
-            color: var(--text-primary);
+            font-size: 24px;
+            font-weight: 700;
+            line-height: 1.3;
+            margin-bottom: 10px;
+            text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+        }
+
+        .card-excerpt {
+            font-size: 14px;
+            color: rgba(255,255,255,0.8);
+            line-height: 1.5;
             display: -webkit-box;
             -webkit-line-clamp: 2;
             -webkit-box-orient: vertical;
             overflow: hidden;
         }
 
-        .card-excerpt {
-            font-size: 0.875rem;
-            color: var(--text-secondary);
-            line-height: 1.6;
-            margin-bottom: 1rem;
-            flex: 1;
-            display: -webkit-box;
-            -webkit-line-clamp: 3;
-            -webkit-box-orient: vertical;
-            overflow: hidden;
+        .meta-info {
+            display: flex;
+            align-items: center;
+            gap: 15px;
+            margin-top: 12px;
+            font-size: 13px;
+            color: rgba(255,255,255,0.7);
+        }
+
+        .source {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .source-icon {
+            width: 16px;
+            height: 16px;
+            background: rgba(255,255,255,0.3);
+            border-radius: 3px;
+        }
+
+        .engagement {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            margin-left: auto;
+        }
+
+        .engagement-item {
+            display: flex;
+            align-items: center;
+            gap: 4px;
         }
 
         .theme-tags {
-            display: flex;
-            gap: 0.5rem;
-            flex-wrap: wrap;
-            margin-bottom: 1rem;
-            min-height: 28px;
+            display: none;
         }
 
         .theme-tag {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.25rem;
-            padding: 0.25rem 0.625rem;
-            border-radius: 12px;
-            font-size: 0.75rem;
-            font-weight: 500;
-            background: var(--bg-card);
+            display: none;
         }
 
-        .theme-tag[data-theme="1"] { background: rgba(74, 144, 226, 0.1); color: var(--theme-1); }
-        .theme-tag[data-theme="2"] { background: rgba(39, 174, 96, 0.1); color: var(--theme-2); }
-        .theme-tag[data-theme="3"] { background: rgba(155, 89, 182, 0.1); color: var(--theme-3); }
-        .theme-tag[data-theme="4"] { background: rgba(243, 156, 18, 0.1); color: var(--theme-4); }
-        .theme-tag[data-theme="5"] { background: rgba(233, 30, 99, 0.1); color: var(--theme-5); }
-        .theme-tag[data-theme="6"] { background: rgba(26, 188, 156, 0.1); color: var(--theme-6); }
-        .theme-tag[data-theme="7"] { background: rgba(124, 179, 66, 0.1); color: var(--theme-7); }
-
-        .card-footer {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            font-size: 0.813rem;
-            color: var(--text-tertiary);
-            padding-top: 1rem;
-            border-top: 1px solid var(--border);
-        }
-
-        .card-stats {
-            display: flex;
-            gap: 1rem;
-        }
 
         /* REDDIT VIEW */
         .reddit-view {
@@ -2001,8 +1972,19 @@
                 const rssItems = rssResults
                     .filter(result => result.status === 'fulfilled')
                     .flatMap(result => result.value);
-                
-                this.manager.allCards = [...legislation, ...redditPosts, ...rssItems];
+
+                const combined = [...legislation, ...redditPosts, ...rssItems];
+                const unique = [];
+                const seen = new Set();
+                combined.forEach(card => {
+                    const key = (card.title + (card.link || '')).toLowerCase();
+                    if (!seen.has(key)) {
+                        seen.add(key);
+                        unique.push(card);
+                    }
+                });
+
+                this.manager.allCards = unique;
                 this.manager.applyFilters();
                 renderView();
             }
@@ -2044,37 +2026,52 @@
         }
 
         function renderCardsView(cards) {
-            return `<div class="card-grid">
-                ${cards.map(card => `
-                    <article class="card" data-type="${card.type}" onclick="openModal('${card.id}')">
-                        <div class="card-type-bar"></div>
-                        ${card.imageUrl ? 
+            const working = [...cards];
+            let featuredIndex = working.findIndex(c => c.type === 'news' || c.type === 'legislation');
+            const featured = featuredIndex !== -1 ? working.splice(featuredIndex, 1)[0] : working.shift();
+
+            const renderCard = (card, isFeatured = false) => `
+                <article class="card${isFeatured ? ' card-featured' : ''}" data-type="${card.type}" onclick="openModal('${card.id}')">
+                    <div class="card-image-container">
+                        ${card.imageUrl ?
                             `<img class="card-image" src="${card.imageUrl}" alt="" loading="lazy">` :
                             `<div class="card-image-placeholder gradient-${card.themes[0] || 1}">${getTypeIcon(card.type)}</div>`
                         }
-                        <div class="card-content">
-                            <div class="card-header">
-                                <span class="card-type-label">
-                                    ${getTypeIcon(card.type)} ${card.type}
-                                </span>
-                                ${card.status ? `<span class="status-${card.statusClass}">${card.status}</span>` : ''}
-                            </div>
-                            <h3 class="card-title">${card.displayTitle}</h3>
-                            <div class="theme-tags">
-                                ${card.themes.map(t => `<span class="theme-tag" data-theme="${t}">${THEMES[t]}</span>`).join('')}
-                            </div>
+                        <div class="text-overlay">
+                            <span class="category-tag">${getTypeIcon(card.type)} ${card.type}</span>
+                            <h2 class="card-title">${card.displayTitle}</h2>
                             <p class="card-excerpt">${card.excerpt}</p>
-                            <div class="card-footer">
-                                <div class="card-stats">
-                                    ${card.type === 'legislation' ? `📋 ${card.fileNumber || 'No file'}` : ''}
-                                    ${card.type === 'discussion' ? `⬆️ ${card.upvotes} 💬 ${card.comments}` : ''}
-                                    ${card.type === 'news' ? `📰 ${card.sourceName || 'News'}` : ''}
-                                </div>
+                            <div class="meta-info">
+                                ${card.type === 'news' ? `
+                                    <div class="source">
+                                        <div class="source-icon"></div>
+                                        <span>${card.sourceName || ''}</span>
+                                    </div>
+                                ` : ''}
+                                ${card.type === 'discussion' ? `
+                                    <div class="engagement">
+                                        <div class="engagement-item">
+                                            <span>⬆</span><span>${card.upvotes}</span>
+                                        </div>
+                                        <div class="engagement-item">
+                                            <span>💬</span><span>${card.comments}</span>
+                                        </div>
+                                    </div>
+                                ` : ''}
+                                ${card.type === 'legislation' ? `
+                                    <div class="source">
+                                        <span>📋 ${card.fileNumber || 'No file'}</span>
+                                    </div>
+                                ` : ''}
                                 <span>${card.dateFormatted}</span>
                             </div>
                         </div>
-                    </article>
-                `).join('')}
+                    </div>
+                </article>`;
+
+            return `<div class="card-grid">
+                ${featured ? renderCard(featured, true) : ''}
+                ${working.map(card => renderCard(card)).join('')}
             </div>`;
         }
 


### PR DESCRIPTION
## Summary
- Revamp default home cards with new image overlay layout and gradient text area
- Render category tag, excerpt, and engagement metadata directly on card images
- Remove duplicate stories and reserve a single featured card slot with consistent aspect ratios

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6896ab4a66e88332aa339acdc27ffa0c