### PR TITLE
Display discussion details and images in home modals

### DIFF
--- a/home
+++ b/home
@@ -1147,6 +1147,12 @@
             color: var(--text-secondary);
         }
 
+        .modal-image {
+            width: 100%;
+            border-radius: 12px;
+            margin: 1rem 0;
+        }
+
         .modal-excerpt {
             font-size: 1rem;
             line-height: 1.6;
@@ -2358,8 +2364,10 @@
                         ${card.comments ? `<span>• 💬 ${card.comments}</span>` : ''}
                     </div>
 
+                    ${card.imageUrl ? `<img class="modal-image" src="${card.imageUrl}" alt="">` : ''}
+
                     <div class="modal-excerpt">
-                        ${card.fullContent || card.excerpt}
+                        ${card.type === 'discussion' ? card.fullContent : card.fullContent || card.excerpt}
                     </div>
 
                     <div class="modal-actions">


### PR DESCRIPTION
## Summary
- show discussion body in home page modals
- render images from original content inside modals

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6896b2a6ed84833297e86b1eb37be2e8