### PR TITLE
Show discussion text and images in home modals

### DIFF
--- a/home
+++ b/home
@@ -1154,6 +1154,14 @@
             margin-bottom: 2rem;
         }
 
+        .modal-image {
+            width: 100%;
+            max-height: 400px;
+            object-fit: cover;
+            border-radius: 8px;
+            margin-bottom: 1.5rem;
+        }
+
         .modal-actions {
             padding: 1.5rem;
             background: var(--bg-card);
@@ -2359,8 +2367,10 @@
                     </div>
 
                     <div class="modal-excerpt">
-                        ${card.fullContent || card.excerpt}
+                        ${card.type === 'discussion' ? card.fullContent : card.fullContent || card.excerpt}
                     </div>
+
+                    ${card.imageUrl ? `<img class="modal-image" src="${card.imageUrl}" alt="">` : ''}
 
                     <div class="modal-actions">
                         <span class="modal-action-text">


### PR DESCRIPTION
## Summary
- display full discussion text in home page modals
- show images from original content within home modals

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6896b2a6ed84833297e86b1eb37be2e8