### PR TITLE
feat: dynamic card sizing and grid layout

### DIFF
--- a/src/data/normalize.ts
+++ b/src/data/normalize.ts
@@ -1,0 +1,44 @@
+export type CardSize = 'large' | 'medium' | 'small';
+
+export interface RawItem {
+  themes?: string[];
+  engagement?: number;
+  date?: string | number | Date;
+  [key: string]: any;
+}
+
+export interface NormalizedItem extends RawItem {
+  cardSize: CardSize;
+}
+
+/**
+ * Normalize raw items and assign a card size based on heuristics.
+ *
+ * cardSize is determined by:
+ *  - number of themes attached to the item
+ *  - engagement level
+ *  - how recent the item is
+ *  - 10% chance promotion to the next larger size
+ */
+export function normalize(item: RawItem): NormalizedItem {
+  const themesCount = item.themes?.length ?? 0;
+  const engagement = item.engagement ?? 0;
+  const timestamp = new Date(item.date ?? Date.now()).getTime();
+  const recencyDays = (Date.now() - timestamp) / (1000 * 60 * 60 * 24);
+
+  let cardSize: CardSize = 'small';
+
+  // Basic heuristic for assigning size
+  if (themesCount > 5 || engagement > 5000 || recencyDays < 2) {
+    cardSize = 'large';
+  } else if (themesCount > 2 || engagement > 1000 || recencyDays < 7) {
+    cardSize = 'medium';
+  }
+
+  // 10% random promotion to the next size up
+  if (Math.random() < 0.1) {
+    cardSize = cardSize === 'large' ? 'large' : cardSize === 'medium' ? 'large' : 'medium';
+  }
+
+  return { ...item, cardSize };
+}

--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,0 +1,32 @@
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  grid-auto-rows: 150px;
+  gap: 1rem;
+}
+
+.card[data-size="large"] {
+  grid-column: span 2;
+  grid-row: span 2;
+}
+
+.card[data-size="medium"] {
+  grid-column: span 2;
+  grid-row: span 1;
+}
+
+.card[data-size="small"] {
+  grid-column: span 1;
+  grid-row: span 1;
+}
+
+@media (max-width: 600px) {
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card[data-size] {
+    grid-column: span 1 !important;
+    grid-row: span 1 !important;
+  }
+}

--- a/src/ui/cardGrid.ts
+++ b/src/ui/cardGrid.ts
@@ -1,0 +1,45 @@
+import { NormalizedItem } from '../data/normalize';
+import { createLargeCard } from './cards/large';
+import { createMediumCard } from './cards/medium';
+import { createSmallCard } from './cards/small';
+
+interface Span {
+  col: number;
+  row: number;
+}
+
+function getSpan(size: NormalizedItem['cardSize']): Span {
+  switch (size) {
+    case 'large':
+      return { col: 2, row: 2 };
+    case 'medium':
+      return { col: 2, row: 1 };
+    default:
+      return { col: 1, row: 1 };
+  }
+}
+
+export function renderCardGrid(container: HTMLElement, items: NormalizedItem[]): void {
+  container.classList.add('card-grid');
+
+  items.forEach((item) => {
+    let card: HTMLElement;
+    switch (item.cardSize) {
+      case 'large':
+        card = createLargeCard(item);
+        break;
+      case 'medium':
+        card = createMediumCard(item);
+        break;
+      default:
+        card = createSmallCard(item);
+    }
+
+    const span = getSpan(item.cardSize);
+    card.style.gridColumn = `span ${span.col}`;
+    card.style.gridRow = `span ${span.row}`;
+    card.dataset.size = item.cardSize;
+
+    container.appendChild(card);
+  });
+}

--- a/src/ui/cards/index.ts
+++ b/src/ui/cards/index.ts
@@ -1,0 +1,3 @@
+export { createLargeCard } from './large';
+export { createMediumCard } from './medium';
+export { createSmallCard } from './small';

--- a/src/ui/cards/large.ts
+++ b/src/ui/cards/large.ts
@@ -1,0 +1,13 @@
+import { NormalizedItem } from '../../data/normalize';
+
+export function createLargeCard(item: NormalizedItem): HTMLElement {
+  const el = document.createElement('article');
+  el.className = 'card card-large';
+  el.dataset.size = 'large';
+  el.innerHTML = `
+    <header><h2>${item.title ?? ''}</h2></header>
+    ${item.image ? `<img src="${item.image}" alt="" />` : ''}
+    <p>${item.summary ?? ''}</p>
+  `;
+  return el;
+}

--- a/src/ui/cards/medium.ts
+++ b/src/ui/cards/medium.ts
@@ -1,0 +1,13 @@
+import { NormalizedItem } from '../../data/normalize';
+
+export function createMediumCard(item: NormalizedItem): HTMLElement {
+  const el = document.createElement('article');
+  el.className = 'card card-medium';
+  el.dataset.size = 'medium';
+  el.innerHTML = `
+    <header><h3>${item.title ?? ''}</h3></header>
+    ${item.image ? `<img src="${item.image}" alt="" />` : ''}
+    <p>${item.summary?.slice(0, 100) ?? ''}</p>
+  `;
+  return el;
+}

--- a/src/ui/cards/small.ts
+++ b/src/ui/cards/small.ts
@@ -1,0 +1,11 @@
+import { NormalizedItem } from '../../data/normalize';
+
+export function createSmallCard(item: NormalizedItem): HTMLElement {
+  const el = document.createElement('article');
+  el.className = 'card card-small';
+  el.dataset.size = 'small';
+  el.innerHTML = `
+    <header><h4>${item.title ?? ''}</h4></header>
+  `;
+  return el;
+}


### PR DESCRIPTION
## Summary
- compute card size during data normalization using theme count, engagement, recency, and a 10% promotion chance
- render cards in a CSS Grid that spans columns/rows based on card size with responsive single-column fallback
- add large, medium, and small card templates with `data-size` hooks for testing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689b6d18d130833285ade44b341cc584