### PR TITLE
Add caching, offline support, and live updates

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,23 @@
+const CACHE_NAME = 'changelog-cache-v1';
+const ASSETS = [
+  '/',
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+      return fetch(event.request).then(response => {
+        const clone = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+        return response;
+      });
+    })
+  );
+});

--- a/src/data/DataFetcher.ts
+++ b/src/data/DataFetcher.ts
@@ -1,0 +1,72 @@
+export interface FeedData {
+  items: unknown[];
+  last_fetched_at: string;
+}
+
+const CACHE_KEY = 'rss_feed_cache';
+const CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
+
+interface CacheEntry {
+  timestamp: number;
+  data: FeedData;
+}
+
+function loadCache(): Record<string, CacheEntry> {
+  try {
+    return JSON.parse(localStorage.getItem(CACHE_KEY) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function saveCache(cache: Record<string, CacheEntry>): void {
+  localStorage.setItem(CACHE_KEY, JSON.stringify(cache));
+}
+
+/**
+ * Fetch multiple RSS feeds with caching and batching.
+ * Stale feeds (older than 24h) are fetched from the network while
+ * fresh feeds are returned from localStorage.
+ * The request sends last_fetched_at for each feed so the server can
+ * skip unchanged feeds.
+ */
+export async function fetchRSSFeeds(feeds: string[]): Promise<Record<string, FeedData>> {
+  const now = Date.now();
+  const cache = loadCache();
+  const result: Record<string, FeedData> = {};
+
+  const stale: string[] = [];
+  const lastFetched: Record<string, string> = {};
+
+  for (const feed of feeds) {
+    const entry = cache[feed];
+    if (entry && now - entry.timestamp < CACHE_TTL) {
+      result[feed] = entry.data;
+      lastFetched[feed] = entry.data.last_fetched_at;
+    } else {
+      stale.push(feed);
+      if (entry) {
+        lastFetched[feed] = entry.data.last_fetched_at;
+      }
+    }
+  }
+
+  if (stale.length) {
+    const resp = await fetch('/rss_feed', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ feeds: stale, last_fetched_at: lastFetched }),
+    });
+    const data: Record<string, FeedData> = await resp.json();
+    for (const feed of stale) {
+      const feedData = data[feed];
+      if (feedData) {
+        cache[feed] = { timestamp: now, data: feedData };
+        result[feed] = feedData;
+      }
+    }
+    saveCache(cache);
+  }
+
+  return result;
+}

--- a/src/data/DataManager.ts
+++ b/src/data/DataManager.ts
@@ -1,0 +1,30 @@
+export interface CardPage {
+  id: string;
+  cards: unknown[];
+}
+
+const PAGE_CACHE = 'card_page_cache';
+
+function loadPages(): Record<string, CardPage> {
+  try {
+    return JSON.parse(sessionStorage.getItem(PAGE_CACHE) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function savePages(pages: Record<string, CardPage>): void {
+  sessionStorage.setItem(PAGE_CACHE, JSON.stringify(pages));
+}
+
+export async function fetchCardPage(id: string): Promise<CardPage> {
+  const pages = loadPages();
+  if (pages[id]) {
+    return pages[id];
+  }
+  const resp = await fetch(`/cards/${id}`);
+  const data: CardPage = await resp.json();
+  pages[id] = data;
+  savePages(pages);
+  return data;
+}

--- a/src/data/liveUpdates.ts
+++ b/src/data/liveUpdates.ts
@@ -1,0 +1,17 @@
+export type UpdateHandler = (data: unknown) => void;
+
+/**
+ * Establishes a live connection using Server-Sent Events when available,
+ * falling back to WebSockets. Incoming messages are forwarded to the
+ * provided handler.
+ */
+export function connectLiveUpdates(handler: UpdateHandler) {
+  if ('EventSource' in window) {
+    const es = new EventSource('/live');
+    es.onmessage = ev => handler(JSON.parse(ev.data));
+    return es;
+  }
+  const ws = new WebSocket('wss://example.com/live');
+  ws.onmessage = ev => handler(JSON.parse(ev.data));
+  return ws;
+}

--- a/src/ui/cards/CardImage.ts
+++ b/src/ui/cards/CardImage.ts
@@ -1,0 +1,8 @@
+export function createLazyImage(src: string, alt: string): HTMLImageElement {
+  const img = document.createElement('img');
+  img.src = src;
+  img.alt = alt;
+  img.loading = 'lazy';
+  img.classList.add('card-image');
+  return img;
+}

--- a/src/ui/cards/card.css
+++ b/src/ui/cards/card.css
@@ -1,0 +1,13 @@
+.card-image {
+  display: block;
+  width: 100%;
+  height: auto;
+  background: linear-gradient(90deg,#eee,#ddd,#eee);
+  background-size: 200% 100%;
+  animation: card-placeholder 1.5s infinite;
+}
+
+@keyframes card-placeholder {
+  0% { background-position: 0 0; }
+  100% { background-position: -200% 0; }
+}


### PR DESCRIPTION
## Summary
- cache and batch RSS feed requests with localStorage and last_fetched_at
- add sessionStorage cache for card pages
- implement basic service worker for offline caching
- lazy load card images with CSS placeholders
- prototype live updates via SSE/WebSocket

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689b6d19c9a48332aa397ce9b6493927