### PR TITLE
Improve media image extraction in RSS

### DIFF
--- a/rss feed basic
+++ b/rss feed basic
@@ -1617,7 +1617,10 @@
             const images = [];
 
             // 1. Check for media:content and media:thumbnail first (most reliable)
-            const mediaContent = item.querySelector('content[medium="image"], thumbnail');
+            let mediaContent = item.querySelector('media\\:content, media\\:thumbnail');
+            if (!mediaContent) {
+                mediaContent = item.querySelector('content[medium="image"], thumbnail');
+            }
             if (mediaContent) {
                 const url = mediaContent.getAttribute('url');
                 if (url) images.push({ url, score: 20, source: 'media:content' });


### PR DESCRIPTION
## Summary
- Prioritize `media:content` and `media:thumbnail` tags when extracting images from RSS items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689ce28b4b3c8332aacdb7f1d983a7eb