### PR TITLE
Handle RSS enclosures without type for image extraction

### DIFF
--- a/rss feed basic
+++ b/rss feed basic
@@ -1624,10 +1624,14 @@
             }
 
             // 2. Check enclosure tags (common for podcasts and media)
-            const enclosures = item.querySelectorAll('enclosure[type^="image"]');
+            const enclosures = item.querySelectorAll('enclosure');
             enclosures.forEach(enc => {
                 const url = enc.getAttribute('url');
-                if (url) images.push({ url, score: 18, source: 'enclosure' });
+                const type = enc.getAttribute('type')?.toLowerCase() || '';
+                const typeIsImage = type.startsWith('image/');
+                if (url && (typeIsImage || (!type && isImageUrl(url)))) {
+                    images.push({ url, score: 18, source: 'enclosure' });
+                }
             });
 
             // 3. Check all namespace variations


### PR DESCRIPTION
## Summary
- Broaden RSS image extraction to scan all `<enclosure>` elements
- Treat missing `type` attributes and `image/jpg` style MIME types as images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689ce28c7b7c8332a3dbda2a090a9ce3