### PR TITLE
feat: broaden image detection for RSS namespace elements

### DIFF
--- a/rss feed basic
+++ b/rss feed basic
@@ -1641,9 +1641,10 @@
                 try {
                     const elements = item.querySelectorAll(selector);
                     elements.forEach(elem => {
+                        const typeAttr = (elem.getAttribute('type') || '').toLowerCase();
                         ['url', 'href', 'src'].forEach(attr => {
                             const url = elem.getAttribute(attr);
-                            if (url && isImageUrl(url)) {
+                            if (url && (isImageUrl(url) || typeAttr.startsWith('image'))) {
                                 images.push({
                                     url,
                                     score: 15,
@@ -1652,7 +1653,7 @@
                             }
                         });
                         const text = elem.textContent?.trim();
-                        if (text && isImageUrl(text)) {
+                        if (text && (isImageUrl(text) || typeAttr.startsWith('image'))) {
                             images.push({
                                 url: text,
                                 score: 14,


### PR DESCRIPTION
## Summary
- Broaden image extraction so RSS namespace elements with `type="image/*"` are accepted even when URLs lack file extensions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689ce28cd3d083329cd2faffe7fa28ea