### PR TITLE
Use HTTPS proxy for remote images

### DIFF
--- a/rss feed basic
+++ b/rss feed basic
@@ -1103,6 +1103,7 @@
         const SOURCES_API = `${XANO_API}/rss_feed`;
         const CONTENT_API = `${XANO_API}/content`;
         const CORS_PROXY = 'https://api.allorigins.win/raw?url=';
+        const IMAGE_PROXY = 'https://images.weserv.nl/?url=';
         
         // Theme configuration
         const THEMES = {
@@ -1333,9 +1334,21 @@
         // Create article card
         function getProxiedImageUrl(originalUrl) {
             if (!originalUrl) return null;
+            // Skip proxy for data URLs or blobs
+            if (/^data:|^blob:/.test(originalUrl)) return originalUrl;
 
-            // Return original URL for now; proxy options can be added if needed
-            return originalUrl;
+            try {
+                const url = new URL(originalUrl, window.location.href);
+                // Normalize HTTP links to HTTPS
+                if (url.protocol === 'http:') {
+                    url.protocol = 'https:';
+                }
+                // Use an HTTPS image proxy to avoid mixed content issues
+                return IMAGE_PROXY + encodeURIComponent(url.href);
+            } catch (e) {
+                // Fallback: proxy the original value directly
+                return IMAGE_PROXY + encodeURIComponent(originalUrl);
+            }
         }
 
         function createArticleCard(article) {


### PR DESCRIPTION
## Summary
- avoid mixed content by adding an image proxy constant
- proxy article images through an HTTPS service with HTTP->HTTPS normalization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689ce28d929c8332a231a9ac87b8a9d6