### PR TITLE
fix: reuse popup with location navigation

### DIFF
--- a/rss feed basic
+++ b/rss feed basic
@@ -1905,15 +1905,14 @@
             
             // Check if popup exists and is not closed
             if (articlePopup && !articlePopup.closed) {
-                // Reuse existing popup
-                articlePopup.document.open();
-                articlePopup.document.write(loadingHTML);
-                articlePopup.document.close();
+                // Reuse existing popup by navigating to the new URL
+                articlePopup.location.href = url;
                 articlePopup.focus();
+                showUpdateToast('Loading article in popup...');
             } else {
-                // Create new popup
+                // Create new popup with loading screen
                 articlePopup = window.open('', 'articleViewer', features);
-                
+
                 if (articlePopup) {
                     articlePopup.document.open();
                     articlePopup.document.write(loadingHTML);


### PR DESCRIPTION
## Summary
- reuse existing article popup by navigating to new URL instead of rewriting document
- add toast feedback when reusing popup to avoid cross-origin errors

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689d610141808332802fa879349d76fe