### PR TITLE
Fix edit feed lookup

### DIFF
--- a/rss feed basic
+++ b/rss feed basic
@@ -2673,7 +2673,9 @@
         }
 
         function editFeed(sourceId) {
-            const feed = feedSources.find(f => (f.id || f.url) === sourceId);
+            const feed = feedSources.find(
+                f => String(f.id || f.url) === String(sourceId)
+            );
             if (feed) {
                 openFeedEditor(feed);
             }


### PR DESCRIPTION
## Summary
- Ensure `editFeed` matches feeds by stringified ID or URL so Edit form opens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689d6285ab6c83328fb63b7497fa7bdf