### PR TITLE
Fix edit feed lookup

### DIFF
--- a/rss feed basic
+++ b/rss feed basic
@@ -2673,7 +2673,11 @@
         }
 
         function editFeed(sourceId) {
-            const feed = feedSources.find(f => (f.id || f.url) === sourceId);
+            // Normalize identifiers to strings before comparison so
+            // numeric IDs and URL strings are matched consistently
+            const feed = feedSources.find(
+                f => String(f.id || f.url) === String(sourceId)
+            );
             if (feed) {
                 openFeedEditor(feed);
             }


### PR DESCRIPTION
## Summary
- Normalize feed identifiers to strings before lookup so Edit opens the correct feed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689d6285ab6c83328fb63b7497fa7bdf