### PR TITLE
feat: surface feed analysis results in editor

### DIFF
--- a/rss-feed-basic.html
+++ b/rss-feed-basic.html
@@ -1299,6 +1299,7 @@
                         <button class="feed-manager-btn" onclick="cancelFeedEdit()">Cancel</button>
                     </div>
                 </div>
+                <div id="analysisOutput" class="test-results" style="display:none;"></div>
                 <div class="feed-list" id="feedList">
                     <!-- Feed items will be loaded here -->
                 </div>
@@ -2840,11 +2841,18 @@
                     body: JSON.stringify({ feed_url: url })
                 });
                 const data = await res.json();
-                console.log('Feed analysis result:', data);
-                alert('Feed analysis complete. Check console for details.');
+                const out = document.getElementById('analysisOutput');
+                if (data.success) {
+                    out.style.display = 'block';
+                    out.innerHTML = `<h4>📊 Analysis Results</h4><pre>${escapeHtml(JSON.stringify(data.recommended_mappings, null, 2))}</pre>`;
+                } else {
+                    out.style.display = 'block';
+                    out.innerHTML = `<p>Analysis failed: ${escapeHtml(data.error || 'Unknown error')}</p>`;
+                }
             } catch (err) {
-                console.error('Feed analysis failed', err);
-                alert('Feed analysis failed. See console for details.');
+                const out = document.getElementById('analysisOutput');
+                out.style.display = 'block';
+                out.innerHTML = `<p>Analysis failed: ${escapeHtml(err.message)}</p>`;
             }
         }
 

--- a/src/data/RSSMappingEditor.ts
+++ b/src/data/RSSMappingEditor.ts
@@ -50,10 +50,18 @@ export function getFeedMappingConfig(feed_id: string) {
  */
 export function updateFeedMappings(feed_id: string, mappings: Record<string, RSSFieldMapping>) {
   // Placeholder implementation for repository documentation
+  const sampleArticle: Record<string, string | null> = {};
+  Object.keys(mappings).forEach(key => {
+    sampleArticle[key] = null;
+  });
   return {
     success: true,
     message: 'Mappings updated successfully',
-    updated_mappings: mappings
+    updated_mappings: mappings,
+    test_result: {
+      success: true,
+      sample_article: sampleArticle
+    }
   };
 }
 


### PR DESCRIPTION
## Summary
- show feed analysis output inside the feed manager instead of console-only logs
- return sample article data from updateFeedMappings so tests can render in UI

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689d70d1ba408332a78915edf895e709